### PR TITLE
Unbundle Cloth Config 1.19.2

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -29,9 +29,9 @@ dependencies {
         exclude(group: "net.fabricmc.fabric-api")
     }
 
-    include(modApi("me.shedaniel.cloth:cloth-config-fabric:${rootProject.cloth_config_version}") {
+    modApi("me.shedaniel.cloth:cloth-config-fabric:${rootProject.cloth_config_version}") {
         exclude(group: "net.fabricmc.fabric-api")
-    })
+    }
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -32,7 +32,7 @@ configurations {
 dependencies {
     forge "net.minecraftforge:forge:${rootProject.forge_version}"
 
-    include(modApi("me.shedaniel.cloth:cloth-config-forge:${rootProject.cloth_config_version}"))
+    modApi("me.shedaniel.cloth:cloth-config-forge:${rootProject.cloth_config_version}")
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionForge")) { transitive = false }


### PR DESCRIPTION
Fixes #7 
You already had the Cloth Config requirement in Fabric manifest, so only this small change was needed.