### PR TITLE
Ask Dynamic FPS to disable loading overlay optimization

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -34,6 +34,9 @@
     "cloth-config": "*"
   },
   "custom": {
+    "dynamic_fps": {
+      "optimized_overlay": false
+    },
     "modmenu": {
       "links": {
         "modmenu.curseforge": "https://curseforge.com/minecraft/mc-mods/rrls",


### PR DESCRIPTION
Hey! I'd like to improve the situation with the Dynamic FPS / rrls incompatibility a bit further.

Our next release (today?) will disable our loading overlay optimization when your mod is present, however I've also implemented an opt out method (https://github.com/juliand665/Dynamic-FPS/pull/103) which I'd prefer we use instead. That way other mods can also disable this if wanted.

You do not need to release this anytime soon since I'm keeping rrls special cased for now, it's just for the future 🙂